### PR TITLE
Fix .neetoci paths filter (supersedes #84)

### DIFF
--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,6 +2,25 @@ version: v1.0
 
 plan: standard-2
 
+paths:
+  - src/**
+  - tests/**
+  - configs/**
+  - typeTemplates/**
+  - .scripts/*
+  - .neetoci/default.yml
+  - package.json
+  - yarn.lock
+  - .node-version
+  - .nvmrc
+  - .prettierrc.js
+  - .eslintrc.js
+  - .eslintignore
+  - jest.config.js
+  - jsconfig.json
+  - resolve.js
+  - "*.config.*"
+
 global_job_config:
   setup:
     - checkout

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -2,33 +2,6 @@ version: v1.0
 
 plan: standard-2
 
-paths:
-  - app/**
-  - bin/**
-  - config/**
-  - db/**
-  - lib/**
-  - test/**
-  - .neetoci/default.yml
-  - .neetoci/scripts/run_eslint_on_modified_files.sh
-  - .neetoci/scripts/run_rubocop_and_erblint_on_modified_files.sh
-  - .neetoci/scripts/check_schema_drift.sh
-  - Gemfile*
-  - package.json
-  - yarn.lock
-  - Rakefile
-  - .env.test
-  - config.ru
-  - .*.yml
-  - .ruby-version
-  - .node-version
-  - .nvmrc
-  - .active_record_doctor.rb
-  - .prettierrc.js
-  - "*.config.*"
-  - .eslintignore
-  - .eslintrc.js
-
 global_job_config:
   setup:
     - checkout

--- a/.neetoci/default.yml
+++ b/.neetoci/default.yml
@@ -7,7 +7,7 @@ paths:
   - tests/**
   - configs/**
   - typeTemplates/**
-  - .scripts/*
+  - .scripts/**
   - .neetoci/default.yml
   - package.json
   - yarn.lock


### PR DESCRIPTION
## What was wrong

#84 added a generic `paths:` whitelist copy-pasted across ~79 repos org-wide (neetozone/neeto-engineering#1970), written for a generic Rails+JS stack. `neeto-cist` is actually a pure JS/TS utility library with no Ruby at all. More critically, the list hardcoded `.neetoci/scripts/run_eslint_on_modified_files.sh`, but this repo's `CiChecks` job actually runs `.scripts/run_eslint_on_modified_files.sh` — a completely different directory — so edits to the real lint script would never trigger CI. bugwatch already flagged this exact mismatch as critical on #84.

## What changed

- Reverted #84.
- Re-added `paths:` pointing at `.scripts/*` (this repo's real script directory) instead of the non-existent `.neetoci/scripts/` path.
- Added the library's real source/config: `src/**`, `tests/**`, `configs/**` (published eslint presets + CLI scripts), `typeTemplates/**`, `.eslintrc.js`, `.eslintignore`, `jest.config.js`, `jsconfig.json`, `resolve.js`, `*.config.*` (babel/rollup configs), `.node-version`/`.nvmrc`, `package.json`, `yarn.lock`.
- Dropped all Rails-only entries (app/, config/, db/, Gemfile, etc.) — no Ruby code in this repo.

Does not touch the CI `commands`/`jobs` sections (out of scope for this fix).

Supersedes #84. Refs neetozone/neeto-engineering#1970.